### PR TITLE
Fix the ArrayTypeMismatchException

### DIFF
--- a/TestPluginFramework/PluginManager.cs
+++ b/TestPluginFramework/PluginManager.cs
@@ -1,11 +1,10 @@
-﻿using McMaster.NETCore.Plugins;
-using Microsoft.Azure;
-using Microsoft.Rest;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
+using McMaster.NETCore.Plugins;
+using Microsoft.Rest;
+using Newtonsoft.Json.Linq;
 
 namespace TestPluginFramework
 {
@@ -16,15 +15,16 @@ namespace TestPluginFramework
             var loaders = new List<PluginLoader>();
             var plugins = new List<IDataCollectorPlugin>();
 
-            foreach (var file in Directory.GetFiles(pluginsDir, "*.dll"))
+            foreach (var depsFile in Directory.GetFiles(pluginsDir, "*.deps.json"))
             {
-                var dllFile = Directory.GetCurrentDirectory() + file;
+                var dllFile = depsFile.Replace(".deps.json", ".dll");
                 var loader = PluginLoader.CreateFromAssemblyFile(
                     dllFile, 
                     sharedTypes: new[] 
                     {
                         typeof(IDataCollectorPlugin),
-                        typeof(TokenCredentials)
+                        typeof(TokenCredentials),
+                        typeof(JObject),
                     }
                 );
 


### PR DESCRIPTION
This ensures the plugin unifies to the same version of Newtonsoft.Json types.

Also, this avoid loading duplicate plugins by using the "deps.json" file as away to figure out what the default plugin assembly is. This avoids creating 51 redundant `PluginLoader` instances.